### PR TITLE
Stop adding profile instructions into the NEAL build

### DIFF
--- a/src/core/_tags
+++ b/src/core/_tags
@@ -7,5 +7,5 @@
 "neal.ml": syntax(camlp4o), package(camlp4.macro), opaque
 "main.ml": package(cmdliner)
 
-true: package(core, dynlink, angstrom), thread, use_menhir, coverage, warn_a, profile, annot, bin_annot
+true: package(core, dynlink, angstrom), thread, use_menhir, coverage, warn_a, annot, bin_annot
 "main.p.native" or "main.native" or "main.byte": debug, linkall, package(yojson, str, cmdliner)


### PR DESCRIPTION
Fixes compilation of NEAL for >= macOS 10.9. We are disabling profile
because Clang's `-pg` option has been deprecated which results in clang
failing with the following error:

```
 the clang compiler does not support -pg option on versions of OS X 10.9
and later
```